### PR TITLE
Reversed order of pipeline inferred from file extension

### DIFF
--- a/src/Outstack/Enveloper/PipeprintBridge/PipeprintPipeline.php
+++ b/src/Outstack/Enveloper/PipeprintBridge/PipeprintPipeline.php
@@ -29,7 +29,7 @@ class PipeprintPipeline implements TemplatePipeline
     {
         $pipeline = [];
         $parts = explode('.', $templateName);
-        foreach (array_slice($parts, 1) as $part) {
+        foreach (array_reverse(array_slice($parts, 1)) as $part) {
             if (in_array($part, $this->extensionsWithoutSemantics)) {
                 continue;
             }


### PR DESCRIPTION
A file which needs to be run through twig first, then mjml should be named `.mjml.twig` rather than `.twig.mjml` because it feels more natural, and works better with syntax highlighting. 

The examples are already named this way, but the logic was the wrong way around.