### PR TITLE
Allow taking hostname from proxies

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -10,6 +10,13 @@ if (!$env) {
     $env = 'dev';
 }
 
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL);
+}
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
+    Request::setTrustedHosts([$trustedHosts]);
+}
+
 $kernel = new AppKernel($env, in_array($env, ['dev', 'test']));
 
 $request = Request::createFromGlobals();


### PR DESCRIPTION
This allows configuration of Symfony's trusted proxy configuration via environment variables. See https://symfony.com/doc/current/deployment/proxies.html .