### PR TITLE
Move bundle definition to bundles.php

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -7,22 +7,12 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        $bundles = [
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new AppBundle\AppBundle(),
-        ];
-
-        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
-            $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
-            $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+        $contents = require $this->getProjectDir().'/config/bundles.php';
+        foreach ($contents as $class => $envs) {
+            if ($envs[$this->environment] ?? $envs['all'] ?? false) {
+                yield new $class();
+            }
         }
-
-        return $bundles;
     }
 
     public function getRootDir()

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,0 +1,23 @@
+<?php
+
+$bundles = [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    AppBundle\AppBundle::class => ['all' => true],
+
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true]
+];
+
+// Allow extra bundles to be added via environment variables
+foreach (array_map('trim', explode(',', getenv('ENVELOPER_EXTENSIONS'))) as $extensionClass) {
+    if (class_exists($extensionClass)) {
+        $bundles[$extensionClass] = ['all' => true];
+    }
+}
+
+return $bundles;


### PR DESCRIPTION
This mimics the directory structure of a new symfony 4 project. Service definition files should also be moved to match the new structure. 

This adds an environment variable, `ENVELOPER_EXTENSIONS`, which is a comma-separated list of bundles classes that will also be loaded. 